### PR TITLE
Fix: Configure Tailwind CSS for Vite project

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,7 @@
     "tailwind-init": "tailwindcss init -p"
   },
   "dependencies": {
-    "@tailwindcss/postcss": "^4.1.10",
     "@tailwindcss/vite": "^4.1.10",
-    "autoprefixer": "^10.4.21",
     "postcss": "^8.5.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,6 +1,0 @@
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-    autoprefixer: {},
-  },
-}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,8 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite';
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tailwindcss()],
 })


### PR DESCRIPTION
I've updated the project configuration to correctly set up Tailwind CSS v4 with Vite.

Here's what I changed:
- Added the `@tailwindcss/vite` plugin to `vite.config.js`.
- Removed the separate `postcss.config.js` as its functionality is now handled by the Vite plugin.
- Removed `autoprefixer` and `@tailwindcss/postcss` from the dependencies in `package.json` as they are either managed by `@tailwindcss/vite` or no longer required with the new Tailwind CSS v4 engine.

Note: I wasn't able to verify these changes by running the development server or building the project due to environment limitations. The changes are based on the official Tailwind CSS v4 integration guide for Vite.